### PR TITLE
Moving from Sqlite3 to pg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.6'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.12.3-x86_64-linux)
       racc (~> 1.4)
+    pg (1.2.3)
     puma (5.4.0)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -140,7 +141,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -158,11 +158,11 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   listen (~> 3.3)
+  pg
   puma (~> 5.0)
   rack-cors
   rails (~> 6.1.4)
   spring
-  sqlite3 (~> 1.4)
   tzinfo-data
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ else
 
 ## Deploying with Heroku
 
+### Solving issue with Gemfile.lock
 I had issues with the Gemfile.lock and with the next error
 ```
 Your bundle only supports platforms ["x86_64-darwin-19"] but your local
@@ -176,3 +177,7 @@ platform is x86_64-linux. Add the current platform to the lockfile with
 
 It's been solved with `bundle lock --add-platform x86_64-linux` and `bundle lock --add-platform ruby`
 [A good article about it here](https://www.moncefbelyamani.com/understanding-the-gemfile-lock-file/)
+
+### Solving issue with Sqlite3
+
+If using Sqlite3 you have the next error with Heroku `Detected sqlite3 gem which is not supported on Heroku:` To solve it follow the [article here](https://devcenter.heroku.com/articles/sqlite3)

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,23 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:
-  <<: *default
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
+  adapter: postgresql
+  database: my_database_development
+  pool: 5
+  timeout: 5000
 test:
-  <<: *default
-  database: db/test.sqlite3
+  adapter: postgresql
+  database: my_database_test
+  pool: 5
+  timeout: 5000
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  database: my_database_production
+  pool: 5
+  timeout: 5000

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,9 @@
 
 ActiveRecord::Schema.define(version: 2021_08_13_074819) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "todos", force: :cascade do |t|
     t.string "title"
     t.boolean "completed"


### PR DESCRIPTION
Heroku doesn't accept Sqlite 3 and give this error when deoploying `Detected sqlite3 gem which is not supported on Heroku`
So moved from Sqlite3 to Postgresql